### PR TITLE
Fix versión desde la cual cambia el nombre de la columna surveyid

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -221,8 +221,8 @@ function encuestascdc_obtiene_estadisticas(array $questionnaires, int $groupid =
 
     $totalalumnos = 0;
     $rankfield = intval($CFG->version) < 2016120509 ? '' : 'value';
-    $surveyfield = intval($CFG->version) < 2019052000 ? 'survey_id' : 'surveyid';
-    $responseonclause = intval($CFG->version) < 2019052000 ? 'r.survey_id = s.id' : 'r.questionnaireid = qu.id';
+    $surveyfield = intval($CFG->version) < 2018051708 ? 'survey_id' : 'surveyid';
+    $responseonclause = intval($CFG->version) < 2018051708 ? 'r.survey_id = s.id' : 'r.questionnaireid = qu.id';
     $groupsql = $groupid > 0 ? "LEFT JOIN {groups_members} gm ON (gm.groupid = :groupid AND gm.userid = r.userid)
 WHERE gm.groupid is not null" : ""; 
     $groupsql2 = $groupid > 0 ? "LEFT JOIN {groups_members} gm ON (gm.groupid = :groupid2 AND gm.userid = r.userid)


### PR DESCRIPTION
En la versión anterior se asumía que la versión necesaria era la 3.7, pero la 3.5 ya utiliza surveyid en vez de survey_id